### PR TITLE
Add missing TCPRouteList

### DIFF
--- a/pkg/apis/specs/v1alpha1/register.go
+++ b/pkg/apis/specs/v1alpha1/register.go
@@ -43,6 +43,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&HTTPRouteGroup{},
 		&HTTPRouteGroupList{},
 		&TCPRoute{},
+		&TCPRouteList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil


### PR DESCRIPTION
This PR:

- Adds missing TCPRouteList to scheme registration

The Informer in #33 requires a lister and a watcher. The lister returned `TCPRouteList`, which was not recognized, and the informer failed to sync.

Fixes #33 