### PR TITLE
Add MarshalJSON to specs/v1alpha2

### DIFF
--- a/pkg/apis/specs/v1alpha2/helpers.go
+++ b/pkg/apis/specs/v1alpha2/helpers.go
@@ -23,3 +23,12 @@ func (h *httpHeaders) UnmarshalJSON(b []byte) error {
 	}
 	return nil
 }
+
+// MarshalJSON converts a given map to array of single value maps
+func (h httpHeaders) MarshalJSON() ([]byte, error) {
+	var returnArr []map[string]string
+	for key, val := range h {
+		returnArr = append(returnArr, map[string]string{key: val})
+	}
+	return json.Marshal(returnArr)
+}


### PR DESCRIPTION
When working with the Kubernetes API, if we do not include this MarshalJSON function, a Create() or Update() will create an HTTPRouteGroup that contains a single map containing all header values, which is different from what is created when specified via yaml (an array of single value maps). This function will make an HTTPRouteGroup object get created as expected.